### PR TITLE
Re-instated ability to download basemaps from AGOL

### DIFF
--- a/maps-app/src/main/java/com/esri/android/mapsapp/basemaps/BasemapsDialogFragment.java
+++ b/maps-app/src/main/java/com/esri/android/mapsapp/basemaps/BasemapsDialogFragment.java
@@ -254,7 +254,22 @@ public class BasemapsDialogFragment extends DialogFragment implements BasemapsAd
 						basemapQuery.setSortField("name").setSortOrder(PortalQueryParameters.SortOrder.ASCENDING);
 						// Find items that match the query
 						final ListenableFuture<PortalQueryResultSet<PortalItem>> itemFuture = portal.findItemsAsync(basemapQuery);
+						itemFuture.addDoneListener(new Runnable() {
+							@Override
+							public void run() {
+								try {
+									PortalQueryResultSet<PortalItem> items = itemFuture.get();
+									mPortalItems.addAll(items.getResults());
+									getBasemapThumbnails();
+									PersistBasemaps.getInstance().storage.put(PUBLIC_BASEMAPS,mBasemapItemList);
+									Log.i(TAG, "Persisting " + PUBLIC_BASEMAPS + " wtih " + mBasemapItemList.size() + " items");
+								} catch (Exception e) {
+									mProgressDialog.dismiss();
+									e.printStackTrace();
+								}
 
+							}
+						});
 					}
 				} catch (InterruptedException e) {
 					e.printStackTrace();

--- a/maps-app/src/main/res/values/strings.xml
+++ b/maps-app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="app_name">Maps App Quartz</string>
+    <string name="app_name">Maps App</string>
     <string name="basemap_thumbnail">basemap thumbnail</string>
 
     <!-- navigation drawer -->


### PR DESCRIPTION
@doneill This PR enables basemaps to be downloaded from AGOL, allowing users to switch basemaps without having to log into a portal.  Not sure how this got left behind.