### PR TITLE
Update libraries to newest versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.1'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-       maven{ url 'https://esri.bintray.com/arcgis' }
-        maven {
-            // url ’http://esri.bintray.com/arcgis'
-            url 'http://android:8080/artifactory/arcgis'
-        }
+        maven { url 'https://esri.bintray.com/arcgis' }
         google()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Dec 13 14:17:23 PST 2017
+#Tue Feb 26 16:09:41 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/maps-app/build.gradle
+++ b/maps-app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
 
     defaultConfig {
         applicationId "com.esri.android.mapsapp"
-        minSdkVersion 17
-        targetSdkVersion 25
+        minSdkVersion 19
+        targetSdkVersion 28
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
 
@@ -28,13 +28,13 @@ android {
 
 dependencies {
     // android support libraries
-    implementation 'com.android.support:support-v4:27.0.2'
-    implementation 'com.android.support:appcompat-v7:27.0.2'
-    implementation 'com.android.support:cardview-v7:27.0.2'
-    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.android.support:appcompat-v7:28.0.'
+    implementation 'com.android.support:cardview-v7:28.0.0'
+    implementation 'com.android.support:design:28.0.0'
 
     // ArcGIS Android API
-    implementation 'com.esri.arcgisruntime:arcgis-android:100.2.0'
+    implementation 'com.esri.arcgisruntime:arcgis-android:100.4.0'
     // square libs
     implementation 'com.jakewharton:butterknife:8.8.1'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'


### PR DESCRIPTION
Bumps the support library versions and move  arcGIS Runtime to 100.4.0
Increases the min SDK to 19 to match the runtime minSDK requirement at API 19.

I've also pulled out the extra maven repository that shouldn't have been there.

I didn't see the build failure mentioned here https://github.com/Esri/maps-app-android/issues/171  while doing this.
