### PR TITLE
Update to use ArcGIS runtime u10

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 A copy of the license is available in the repository's [license.txt](https://github.com/Esri/maps-app-android/blob/master/license.txt) file.
 
-For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/guide/license-your-app.htm).
+For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/license-and-deployment).
 
 [](Esri Tags: ArcGIS Android Mobile)
 [](Esri Language: Java)​

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 
 A copy of the license is available in the repository's [license.txt](https://github.com/Esri/maps-app-android/blob/master/license.txt) file.
 
-For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/license-and-deployment).
+For information about licensing your deployed app, see [License your app](https://developers.arcgis.com/android/license-and-deployment/).
 
 [](Esri Tags: ArcGIS Android Mobile)
 [](Esri Language: Java)​

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,7 @@
+# Release 1.0.11
+
+- Support for ArcGIS Runtime SDK for Android 100.10.0
+
 # Release 1.0.10
 
 - Updates project to favor the use of secured `https` rather than `http`

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:4.1.1'
     }
 }
 
@@ -20,21 +20,21 @@ allprojects {
 // Define versions in a single place
 ext {
     // Sdk and tools
-    minSdkVersion = 21
+    minSdkVersion = 23
     targetSdkVersion = 29
     compileSdkVersion = 29
 
     // App dependencies
-    appcompatLibraryVersion = '1.1.0'
+    appcompatLibraryVersion = '1.2.0'
     cardviewLibraryVersion = '1.0.0'
-    materialLibraryVersion = '1.0.0'
+    materialLibraryVersion = '1.2.1'
     legacyLibraryVersion = '1.0.0'
 
-    runtimeVersion = '100.9.0'
+    runtimeVersion = '100.10.0'
     butterknifeVersion = '10.2.0'
     robotiumVersion = '5.6.3'
     httpcomponentsVersion = '4.3.5.1'
-    runnerVersion = '1.1.0'
+    runnerVersion = '1.3.0'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
     }
 }
 
@@ -27,7 +27,7 @@ ext {
     // App dependencies
     appcompatLibraryVersion = '1.2.0'
     cardviewLibraryVersion = '1.0.0'
-    materialLibraryVersion = '1.2.1'
+    materialLibraryVersion = '1.3.0'
     legacyLibraryVersion = '1.0.0'
 
     runtimeVersion = '100.10.0'

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ mapView.setMap(map);
 
 ### Accessing your organization's basemaps
 
-As an administrator of an ArcGIS Online organization or Portal, you can configure the basemaps that your users can switch between via a [group](http://doc.arcgis.com/en/arcgis-online/share-maps/share-items.htm). Applications can leverage this configuration using the [Portal API](https://developers.arcgis.com/android/arcgis-organization-portals). The Maps App does this by an asynchronous call to find the group containing web maps in the basemap gallery. With the returned group id, the collection of basemaps is retrieved from the portal.
+As an administrator of an ArcGIS Online organization or Portal, you can configure the basemaps that your users can switch between via a [group](http://doc.arcgis.com/en/arcgis-online/share-maps/share-items.htm). Applications can leverage this configuration using the [Portal API](https://developers.arcgis.com/android/arcgis-organization-portals/). The Maps App does this by an asynchronous call to find the group containing web maps in the basemap gallery. With the returned group id, the collection of basemaps is retrieved from the portal.
 
 ```java
 PortalQueryParams queryParams = new PortalQueryParams();
@@ -129,7 +129,7 @@ In the Maps App, `LocatorTask`s are initialized using an online locator provided
 mLocator = new LocatorTask(getString("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
 ```
 
-You can also provision your own [custom geocode service](https://doc.arcgis.com/en/arcgis-online/administer/configure-services.htm#ESRI_SECTION1_0A9A071A7AB748028C8213D1D863FA18) to support your organization. Before using the `LocatorTask` to geocode or search for places, the `LocatorTask` must be `LOADED`. The loadable pattern is described [here](https://developers.arcgis.com/android/programming-patterns/loadable). `LocatorTask` operations are performed asynchronously using `ListenableFutures`, an implementation of Java’s Future interface. `ListenableFutures` add the ability to attach a listener that runs upon completion of the task. One of the first user interactions the Maps App supports is suggesting places near the device location.
+You can also provision your own [custom geocode service](https://doc.arcgis.com/en/arcgis-online/administer/configure-services.htm#ESRI_SECTION1_0A9A071A7AB748028C8213D1D863FA18) to support your organization. Before using the `LocatorTask` to geocode or search for places, the `LocatorTask` must be `LOADED`. The loadable pattern is described [here](https://developers.arcgis.com/android/programming-patterns/loadable/). `LocatorTask` operations are performed asynchronously using `ListenableFutures`, an implementation of Java’s Future interface. `ListenableFutures` add the ability to attach a listener that runs upon completion of the task. One of the first user interactions the Maps App supports is suggesting places near the device location.
 
 ### Place suggestions
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,7 @@ mapView.setMap(map);
 
 ### Accessing your organization's basemaps
 
-As an administrator of an ArcGIS Online organization or Portal, you can configure the basemaps that your users can switch between via a [group](http://doc.arcgis.com/en/arcgis-online/share-maps/share-items.htm). Applications can leverage this configuration using the [Portal API](https://developers.arcgis.com/android/latest/guide/access-the-arcgis-platform.htm#ESRI_SECTION2_B8EDBBD3D4F1499C80AF43CFA73B8292). The Maps App does this by an asynchronous call to find the group containing web maps in the basemap gallery. With the returned group id, the collection of basemaps is retrieved from the portal.
+As an administrator of an ArcGIS Online organization or Portal, you can configure the basemaps that your users can switch between via a [group](http://doc.arcgis.com/en/arcgis-online/share-maps/share-items.htm). Applications can leverage this configuration using the [Portal API](https://developers.arcgis.com/android/arcgis-organization-portals). The Maps App does this by an asynchronous call to find the group containing web maps in the basemap gallery. With the returned group id, the collection of basemaps is retrieved from the portal.
 
 ```java
 PortalQueryParams queryParams = new PortalQueryParams();
@@ -129,7 +129,7 @@ In the Maps App, `LocatorTask`s are initialized using an online locator provided
 mLocator = new LocatorTask(getString("http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer");
 ```
 
-You can also provision your own [custom geocode service](https://doc.arcgis.com/en/arcgis-online/administer/configure-services.htm#ESRI_SECTION1_0A9A071A7AB748028C8213D1D863FA18) to support your organization. Before using the `LocatorTask` to geocode or search for places, the `LocatorTask` must be `LOADED`. The loadable pattern is described [here](https://developers.arcgis.com/android/latest/guide/loadable-pattern.htm). `LocatorTask` operations are performed asynchronously using `ListenableFutures`, an implementation of Java’s Future interface. `ListenableFutures` add the ability to attach a listener that runs upon completion of the task. One of the first user interactions the Maps App supports is suggesting places near the device location.
+You can also provision your own [custom geocode service](https://doc.arcgis.com/en/arcgis-online/administer/configure-services.htm#ESRI_SECTION1_0A9A071A7AB748028C8213D1D863FA18) to support your organization. Before using the `LocatorTask` to geocode or search for places, the `LocatorTask` must be `LOADED`. The loadable pattern is described [here](https://developers.arcgis.com/android/programming-patterns/loadable). `LocatorTask` operations are performed asynchronously using `ListenableFutures`, an implementation of Java’s Future interface. `ListenableFutures` add the ability to attach a listener that runs upon completion of the task. One of the first user interactions the Maps App supports is suggesting places near the device location.
 
 ### Place suggestions
 
@@ -166,7 +166,7 @@ mLocator.loadAsync();
 
 ### Geocoding
 
-Once a suggestion in the list has been selected by the user, the suggested address is geocoded using the `geocodeAsync` method of the `LocatorTask`. Along with the address, specific [geocoding parameters](https://developers.arcgis.com/android/latest/guide/search-for-places-geocoding-.htm#ESRI_SECTION2_48C5C281B21B4BF1BBBDBCEA71F105B9) can be set to tune the results. For example, in the Maps App, we set the preferred location and refine that further by setting a boundary of the area to search for matching addresses.
+Once a suggestion in the list has been selected by the user, the suggested address is geocoded using the `geocodeAsync` method of the `LocatorTask`. Along with the address, specific [geocoding parameters](https://developers.arcgis.com/android/api-reference/reference/com/esri/arcgisruntime/tasks/geocode/GeocodeParameters.html) can be set to tune the results. For example, in the Maps App, we set the preferred location and refine that further by setting a boundary of the area to search for matching addresses.
 
 ```java
 mGeocodeParams = new GeocodeParameters();

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Feb 26 16:09:41 PST 2019
+#Tue Nov 24 15:37:38 PST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/maps-app/build.gradle
+++ b/maps-app/build.gradle
@@ -10,7 +10,7 @@ android {
         targetSdkVersion rootProject.targetSdkVersion
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         versionCode 1
-        versionName '1.0.10'
+        versionName '1.0.11'
     }
 
     packagingOptions {


### PR DESCRIPTION
- Update versions - 
   Android Gradle Plugin Version - 4.1.2
   Gradle version - 6.5
   Min SDK - 23 required by ArcGIS runtime
   ArcGIS runtime version - 100.10.0
   test runner version
   materialLibraryVersion
   appcompatLibraryVersion

- Update app versionName to 1.0.11